### PR TITLE
Update nextbot_behavior.sp

### DIFF
--- a/source/redbots3/nextbot_behavior.sp
+++ b/source/redbots3/nextbot_behavior.sp
@@ -487,7 +487,7 @@ public Action CTFBotTacticalMonitor_Update(BehaviorAction action, int actor, flo
 	
 	if (!ShouldUseTeleporter(actor))
 	{
-		CountdownTimer pFindTeleporterTimer = CountdownTimer(action.Get(0x70));
+		CountdownTimer pFindTeleporterTimer = CountdownTimer(action + 0x70);
 		
 		if (pFindTeleporterTimer.Address)
 		{


### PR DESCRIPTION
Normally when we try to read this from an entity, we prefer to use its Address pointer plus the offset to get the timer's pointer from memory. Assuming the same thing, we wouldn't use LoadFromAddress here, but instead just add this pointer and the offset to get the timer's pointer from memory.